### PR TITLE
Fix when there is no path on layer called PATH and it has a cel filled of mask pixels

### DIFF
--- a/PathAnimator/path_finder.lua
+++ b/PathAnimator/path_finder.lua
@@ -102,7 +102,7 @@ function findEndDots(celToExplore)
       end
     end
   end
-  if #endDots <= 2 then
+  if #endDots > 0 and #endDots <= 2 then
     return endDots
   else
     return nil
@@ -415,7 +415,3 @@ function makePath(pathVectorExtended, timeVectorN, frameCount, translationFun, t
 
   return outputCoordinatesVector
 end
-
-
-
-


### PR DESCRIPTION
A "cel filled of mask pixels" is reproducible:
. New Sprite, then
. the only active cel in the layer is like a cel filled of mask pixels.